### PR TITLE
Fix color scheme overrides

### DIFF
--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -88,11 +88,11 @@ it('Creates a simple css variable based theme with light and dark', () => {
         --color: teal
       }
 
-      .chair .light {
+      .chair.light {
         --color: beige
       }
 
-      .chair .dark {
+      .chair.dark {
         --color: darkpurple
       }
     `,

--- a/__tests__/precedence.test.ts
+++ b/__tests__/precedence.test.ts
@@ -1,0 +1,100 @@
+import { run } from './test-utils';
+
+jest.mock('browserslist', () => () => ['chrome 76']);
+
+it('Overrides all themes from default', () => {
+  const config = {
+    default: {
+      light: {
+        color: 'red'
+      },
+      dark: {
+        color: 'blue'
+      }
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+      }
+
+      :root {
+        --color: red;
+      }
+      
+      .dark {
+        --color: blue;
+      }
+
+      .mint {
+        --color: teal;
+      }
+    `,
+    {
+      config
+    }
+  );
+});
+
+it('Overrides dark themes from default', () => {
+  const config = {
+    default: {
+      light: {
+        color: 'red'
+      },
+      dark: {
+        color: 'blue'
+      }
+    },
+    mint: {
+      light: {
+        color: 'purple'
+      },
+      dark: {
+        color: 'teal'
+      }
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+      }
+
+      :root {
+        --color: red;
+      }
+      
+      .dark {
+        --color: blue;
+      }
+
+      .mint.light {
+        --color: purple;
+      }
+
+      .mint.dark {
+        --color: teal;
+      }
+    `,
+    {
+      config
+    }
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,12 +379,12 @@ const modernTheme = (
     ) {
       rules.push(
         createModernTheme(
-          isDefault ? rootClass : `${rootClass} .light`,
+          isDefault ? rootClass : `${rootClass}.light`,
           filterUsed('light'),
           localize
         ),
         createModernTheme(
-          isDefault ? '.dark' : `${rootClass} .dark`,
+          isDefault ? '.dark' : `${rootClass}.dark`,
           filterUsed('dark'),
           localize
         )


### PR DESCRIPTION
When a non-default theme is trying to override the color value of a default `dark`/`light` theme, the generated classnames to set the css var are wrong. 

Since the assumption is that the `color-scheme` class and the `theme` class are all on the same element, they need to use a single selector, not the nested one (the space in the current output). 