### PR TITLE
Make all css-vars lowercase

### DIFF
--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -8,7 +8,8 @@ it('Creates a simple css variable based theme', () => {
   const config = {
     default: {
       color: 'purple',
-      extras: 'black'
+      extras: 'black',
+      otherColor: 'blue'
     },
     mint: {
       color: 'teal'
@@ -19,17 +20,20 @@ it('Creates a simple css variable based theme', () => {
     `
       .test {
         color: @theme color;
+        background-color: @theme otherColor;
         background-image: linear-gradient(to right, @theme color, @theme color)
       }
     `,
     `
       .test {
         color: var(--color);
+        background-color: var(--othercolor);
         background-image: linear-gradient(to right, var(--color), var(--color))
       }
 
       :root {
-        --color: purple
+        --color: purple;
+        --othercolor: blue
       }
 
       .mint {

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,7 +328,7 @@ const createModernTheme = (
   const rule = postcss.rule({ selector });
   const decls = Object.entries(theme).map(([prop, value]) =>
     postcss.decl({
-      prop: `--${transform(prop)}`,
+      prop: `--${transform(prop).toLowerCase()}`,
       value: `${value}`
     })
   );
@@ -379,7 +379,10 @@ const modernTheme = (
     rule.walkDecls(decl => {
       while (decl.value.includes('@theme')) {
         const key = parseThemeKey(decl.value);
-        decl.value = replaceTheme(decl.value, `var(--${localize(key)})`);
+        decl.value = replaceTheme(
+          decl.value,
+          `var(--${localize(key).toLowerCase()})`
+        );
         usage.add(key);
       }
     });


### PR DESCRIPTION
Safari 13.1 was converting everything to lowercase when setting things, but still referencing camelCase
