### PR TITLE
feat: generating single theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,10 +303,8 @@ postcss([
 }
 ```
 
-**Note**
-
 ```
-To generate the remaining themes, specify the theme you want to generate using defaultTheme option.
+NOTE: To generate the remaining themes, specify the theme you want to generate using defaultTheme option.
 ```
 
 ## Debug

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ postcss([
 }
 ```
 
+```
+Note: To generate the remaining themes, specify the theme you want to generate using defaultTheme option.
+```
+
 ## Debug
 
 This package uses the npm package [debug](https://www.npmjs.com/package/debug) to log errors while it's running.

--- a/README.md
+++ b/README.md
@@ -303,8 +303,10 @@ postcss([
 }
 ```
 
+**Note**
+
 ```
-Note: To generate the remaining themes, specify the theme you want to generate using defaultTheme option.
+To generate the remaining themes, specify the theme you want to generate using defaultTheme option.
 ```
 
 ## Debug

--- a/README.md
+++ b/README.md
@@ -253,6 +253,56 @@ postcss([
 ]);
 ```
 
+### forceSingleTheme - only legacy
+
+By default this plugin will generate multiple themes when the component configuration is set to default. forceSingleTheme enables to override that and generate seperate themes. (ex: you have 3 themes but your component only uses 1, then only 1 extra set of theme is produced).
+
+You can use the `forceSingleTheme` to force these single themes to be generated.
+
+### Usage
+
+```js
+postcss([
+  require('postcss-themed')({
+    config,
+    defaultTheme: 'light',
+    forceSingleTheme: true
+  })
+]);
+```
+
+**Input**
+
+```css
+.light {
+  color: white;
+  border: 10px solid white;
+}
+
+.dark {
+  color: black;
+  border: 10px solid black;
+}
+```
+
+**Run**
+
+```css
+.light {
+  color: @theme color;
+  border: @theme border-width solid @theme color;
+}
+```
+
+**Output**
+
+```css
+.light {
+  color: white;
+  border: 10px solid white;
+}
+```
+
 ## Debug
 
 This package uses the npm package [debug](https://www.npmjs.com/package/debug) to log errors while it's running.

--- a/__tests__/legacy.test.ts
+++ b/__tests__/legacy.test.ts
@@ -732,7 +732,6 @@ it('overrides themes to single theme', () => {
   }
   `;
 
-  // @ts-ignore
   return postcss([plugin({ config, defaultTheme: 'quickBooks', forceSingleTheme: true })])
     .process(input, { from: undefined })
     .catch(e => {

--- a/__tests__/legacy.test.ts
+++ b/__tests__/legacy.test.ts
@@ -713,3 +713,31 @@ it('dark themes', () => {
     }
   );
 });
+
+it('overrides themes to single theme', () => {
+  const config = {
+    newDefault: {
+      color: 'black'
+    },
+    shinyNewProduct: {
+      color: 'red',
+      width: '1rem'
+    }
+  };
+
+  const input = `
+  .test {
+    background-color: @theme color;
+    width: @theme width;
+  }
+  `;
+
+  // @ts-ignore
+  return postcss([plugin({ config, defaultTheme: 'quickBooks', forceSingleTheme: true })])
+    .process(input, { from: undefined })
+    .catch(e => {
+      expect(e.message).toContain(
+        "Theme 'quickBooks' does not contain key 'color'"
+      );
+  });
+});

--- a/__tests__/legacy.test.ts
+++ b/__tests__/legacy.test.ts
@@ -742,6 +742,43 @@ it('overrides themes to single theme', () => {
   });
 });
 
+it('when theme = light , forceSingleTheme = true, single selector is generated', () => {
+  const config = {
+    default: {
+      color: 'purple',
+      width: '1px'
+    },
+    light: {
+      color: 'white',
+      width: '10px'
+    },
+    dark : {
+      color: 'black',
+      width: '20px'
+    }
+  };
+
+  return run(
+    `
+      .expanded, .foo {
+        color: @theme color;
+        width: @theme width;
+      }
+    `,
+    `
+      .expanded, .foo {
+        color: white;
+        width: 10px;
+      }
+    `,
+    {
+      config,
+      defaultTheme: 'light',
+      forceSingleTheme: true,
+    }
+  );
+});
+
 it('when theme = light , forceSingleTheme = false, multiple selectors are generated', () => {
   const config = {
     default: {
@@ -783,43 +820,6 @@ it('when theme = light , forceSingleTheme = false, multiple selectors are genera
       config,
       defaultTheme: 'light',
       forceSingleTheme: false,
-    }
-  );
-});
-
-it('when theme = light , forceSingleTheme = true, single selector is generated', () => {
-  const config = {
-    default: {
-      color: 'purple',
-      width: '1px'
-    },
-    light: {
-      color: 'white',
-      width: '10px'
-    },
-    dark : {
-      color: 'black',
-      width: '20px'
-    }
-  };
-
-  return run(
-    `
-      .expanded, .foo {
-        color: @theme color;
-        width: @theme width;
-      }
-    `,
-    `
-      .expanded, .foo {
-        color: white;
-        width: 10px;
-      }
-    `,
-    {
-      config,
-      defaultTheme: 'light',
-      forceSingleTheme: true,
     }
   );
 });

--- a/__tests__/legacy.test.ts
+++ b/__tests__/legacy.test.ts
@@ -741,3 +741,85 @@ it('overrides themes to single theme', () => {
       );
   });
 });
+
+it('when theme = light , forceSingleTheme = false, multiple selectors are generated', () => {
+  const config = {
+    default: {
+      color: 'purple',
+      width: '1px'
+    },
+    light: {
+      color: 'white',
+      width: '10px'
+    },
+    dark : {
+      color: 'black',
+      width: '20px'
+    }
+  };
+
+  return run(
+    `
+      .expanded, .foo {
+        width: @theme width;
+        color: @theme color;
+      }
+    `,
+    `
+      .expanded, .foo {
+        width: 10px;
+        color: white;
+      }
+      .default .expanded,.default  .foo {
+        width: 1px;
+        color: purple;
+      }
+      .dark .expanded,.dark  .foo {
+        width: 20px;
+        color: black;
+      }
+    `,
+    {
+      config,
+      defaultTheme: 'light',
+      forceSingleTheme: false,
+    }
+  );
+});
+
+it('when theme = light , forceSingleTheme = true, single selector is generated', () => {
+  const config = {
+    default: {
+      color: 'purple',
+      width: '1px'
+    },
+    light: {
+      color: 'white',
+      width: '10px'
+    },
+    dark : {
+      color: 'black',
+      width: '20px'
+    }
+  };
+
+  return run(
+    `
+      .expanded, .foo {
+        color: @theme color;
+        width: @theme width;
+      }
+    `,
+    `
+      .expanded, .foo {
+        color: white;
+        width: 10px;
+      }
+    `,
+    {
+      config,
+      defaultTheme: 'light',
+      forceSingleTheme: true,
+    }
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,9 +293,9 @@ const legacyTheme = (
       }
     });
 
-    let createNewThemeRules: postcss.Rule[] = [];
+    let createNewThemeRules: postcss.Rule[];
     if(forceSingleTheme) {
-      createNewThemeRules;
+      createNewThemeRules = [];
     } else {
       createNewThemeRules = createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export interface PostcssThemeOptions {
   defaultTheme?: string;
   /** Transform CSS variable names similar to CSS-Modules */
   modules?: string | ScopedNameFunction;
+  /** Determines if we want to use all themes or individual themes */
+  forceSingleTheme?: boolean;
 }
 
 /** Get the theme variable name from a string */
@@ -267,6 +269,7 @@ const legacyTheme = (
   const {
     defaultTheme = 'default',
     forceSingleTheme = false,
+    forceEmptyThemeSelectors,
   } = options;
   let newRules: postcss.Rule[] = [];
 
@@ -291,18 +294,18 @@ const legacyTheme = (
     });
 
     let createNewThemeRules: postcss.Rule[] = [];
-        if(forceSingleTheme) {
-            createNewThemeRules;
-        } else {
-            createNewThemeRules = createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
-        }
-        newRules = [
-            ...newRules,
-            ...createNewThemeRules
-        ];
+    if(forceSingleTheme) {
+      createNewThemeRules;
+    } else {
+      createNewThemeRules = createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
+    }
+    newRules = [
+      ...newRules,
+      ...createNewThemeRules
+    ];
   });
 
-  if (options.forceEmptyThemeSelectors) {
+  if (forceEmptyThemeSelectors) {
     const themes = Object.keys(componentConfig);
     const extra = new Set<string>();
 
@@ -322,7 +325,7 @@ const legacyTheme = (
   }
 
   newRules.forEach(r => {
-    if (options.forceEmptyThemeSelectors || (r.nodes && r.nodes.length > 0)) {
+    if (forceEmptyThemeSelectors || (r.nodes && r.nodes.length > 0)) {
       root.append(r);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,10 @@ const legacyTheme = (
   componentConfig: PostcssStrictThemeConfig,
   options: PostcssThemeOptions
 ) => {
-  const defaultTheme = options.defaultTheme || 'default';
+  const {
+    defaultTheme = 'default',
+    forceSingleTheme = false,
+  } = options;
   let newRules: postcss.Rule[] = [];
 
   root.walkRules(rule => {
@@ -287,10 +290,16 @@ const legacyTheme = (
       }
     });
 
-    newRules = [
-      ...newRules,
-      ...createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
-    ];
+    let createNewThemeRules: postcss.Rule[] = [];
+        if(forceSingleTheme) {
+            createNewThemeRules;
+        } else {
+            createNewThemeRules = createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
+        }
+        newRules = [
+            ...newRules,
+            ...createNewThemeRules
+        ];
   });
 
   if (options.forceEmptyThemeSelectors) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,6 +299,7 @@ const legacyTheme = (
     } else {
       createNewThemeRules = createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
     }
+
     newRules = [
       ...newRules,
       ...createNewThemeRules


### PR DESCRIPTION
# What Changed
Adding flag to generate single themes
# Why
When all the styles doesn't need to be necessarily generated , we can use the forceSingleTheme Flag to control and generate single themes. 

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
