### PR TITLE
fix bug where root themes dark mode would be overridden by next theme

### DIFF
--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -86,7 +86,7 @@ it('Creates a simple css variable based theme with light and dark', () => {
         --color: black
       }
 
-      .mint {
+      .mint.light {
         --color: teal
       }
 

--- a/__tests__/precedence.test.ts
+++ b/__tests__/precedence.test.ts
@@ -36,7 +36,7 @@ it('Overrides all themes from default', () => {
         --color: blue;
       }
 
-      .mint {
+      .mint.light {
         --color: teal;
       }
     `,


### PR DESCRIPTION
# What Changed

allow for simpler configuration of theme overrides when base theme has light/dark mode enabled

# Why

simpler configuration is good!

Todo:

- [x] Add tests

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.1.3-canary.11.179`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
