### PR TITLE
Force Single Theme in Modern Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,25 @@ In practice, we use this to generate extra CSS files for teams that only need a 
 ### Usage
 
 ```js
+const config = {
+  default: {
+    light: {
+      color: 'purple'
+    },
+    dark: {
+      color: 'black'
+    }
+  },
+  chair: {
+    light: {
+      color: 'beige'
+    },
+    dark: {
+      color: 'dark-purple'
+    }
+  }
+};
+
 postcss([
   require('postcss-themed')({
     config,
@@ -275,38 +294,29 @@ postcss([
 **Input**
 
 ```css
-.light {
-  color: white;
-  border: 10px solid white;
-}
-
-.dark {
-  color: black;
-  border: 10px solid black;
-}
-```
-
-**Run**
-
-```css
-.light {
+.test {
   color: @theme color;
-  border: @theme border-width solid @theme color;
 }
 ```
 
 **Output**
 
 ```css
-.light {
-  color: white;
-  border: 10px solid white;
+.test {
+  color: var(--color);
+}
+
+:root {
+  --color: beige;
+}
+
+.dark {
+  --color: darkpurple;
 }
 ```
 
-```
-NOTE: To generate the remaining themes, specify the theme you want to generate using defaultTheme option.
-```
+As you can see in the above example, the second theme is completely ignored.
+If only a light theme is specified, we don't even need to specify CSS variables to add the theme.
 
 ## Debug
 

--- a/README.md
+++ b/README.md
@@ -253,11 +253,12 @@ postcss([
 ]);
 ```
 
-### forceSingleTheme - only legacy
+### forceSingleTheme
 
-By default this plugin will generate multiple themes when the component configuration is set to default. forceSingleTheme enables to override that and generate seperate themes. (ex: you have 3 themes but your component only uses 1, then only 1 extra set of theme is produced).
-
-You can use the `forceSingleTheme` to force these single themes to be generated.
+This is a niche option which only inserts the `defaultTheme` and ignores any others.
+At first glance, this may seem strange because this plugin primarily allows you to support _many_ themes in a single CSS file.
+This option helps if you want to generate _many_ CSS files, each with their own theme. You'll run PostCSS multiple times, switching the default theme while enabling `forceSingleTheme`.
+In practice, we use this to generate extra CSS files for teams that only need a single theme. The main CSS file still has all of them, but teams can optionally use the one that only has the theme they need.
 
 ### Usage
 

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -104,6 +104,90 @@ it('Creates a simple css variable based theme with light and dark', () => {
   );
 });
 
+it('Produces a single theme', () => {
+  const config = {
+    default: {
+      light: {
+        color: 'purple'
+      },
+      dark: {
+        color: 'black'
+      }
+    },
+    mint: {
+      color: 'teal'
+    },
+    chair: {
+      light: {
+        color: 'beige'
+      },
+      dark: {
+        color: 'darkpurple'
+      }
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+      }
+
+      :root {
+        --color: beige;
+      }
+
+      .dark {
+        --color: darkpurple;
+      }
+    `,
+    {
+      config,
+      defaultTheme: 'chair',
+      forceSingleTheme: true
+    }
+  );
+});
+
+it('Produces a single theme without variables if possible', () => {
+  const config = {
+    default: {
+      light: {
+        color: 'purple'
+      },
+      dark: {
+        color: 'black'
+      }
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: teal;
+      }
+    `,
+    {
+      config,
+      defaultTheme: 'mint',
+      forceSingleTheme: true
+    }
+  );
+});
+
 it('works with nested', () => {
   const config = {
     default: {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "postcss-nested": "^4.1.2",
     "prettier": "^1.16.4",
     "tapable": "^1.1.3",
-    "typescript": "^3.7.4"
+    "typescript": "4.0.2"
   },
   "eslintConfig": {
     "extends": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,7 @@ const legacyTheme = (
   const {
     defaultTheme = 'default',
     forceSingleTheme = false,
-    forceEmptyThemeSelectors,
+    forceEmptyThemeSelectors
   } = options;
   let newRules: postcss.Rule[] = [];
 
@@ -294,16 +294,18 @@ const legacyTheme = (
     });
 
     let createNewThemeRules: postcss.Rule[];
-    if(forceSingleTheme) {
+    if (forceSingleTheme) {
       createNewThemeRules = [];
     } else {
-      createNewThemeRules = createNewRules(componentConfig, rule, themedDeclarations, defaultTheme)
+      createNewThemeRules = createNewRules(
+        componentConfig,
+        rule,
+        themedDeclarations,
+        defaultTheme
+      );
     }
 
-    newRules = [
-      ...newRules,
-      ...createNewThemeRules
-    ];
+    newRules = [...newRules, ...createNewThemeRules];
   });
 
   if (forceEmptyThemeSelectors) {
@@ -389,6 +391,7 @@ const modernTheme = (
 ) => {
   const usage = new Set<string>();
   const defaultTheme = options.defaultTheme || 'default';
+  const singleTheme = options.forceSingleTheme || false;
   const resourcePath = root.source ? root.source.input.file : '';
   const localize = getLocalizeFunction(options.modules, resourcePath);
   // 1. Walk each declaration and replace theme vars with CSS vars

--- a/yarn.lock
+++ b/yarn.lock
@@ -6424,10 +6424,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@^3.7.4:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
+typescript@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# What Changed

Adding support for the `forceSingleTheme` option in the modern parser, which will generate only the defaultTheme.

# Why

It was previously only implemented in the Legacy parser.

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
