### PR TITLE
Merge Single Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,12 @@ postcss([
 
 ### forceSingleTheme
 
-This is a niche option which only inserts the `defaultTheme` and ignores any others.
-At first glance, this may seem strange because this plugin primarily allows you to support _many_ themes in a single CSS file.
-This option helps if you want to generate _many_ CSS files, each with their own theme. You'll run PostCSS multiple times, switching the default theme while enabling `forceSingleTheme`.
+This is a niche option which only inserts a single theme.
+At first glance, this may seem strange because this plugin primarily allows you to support _many_ themes in a _single_ CSS file.
+This option helps if you want to generate _many_ CSS files, each with their own theme. You'll run PostCSS multiple times, switching the single theme.
 In practice, we use this to generate extra CSS files for teams that only need a single theme. The main CSS file still has all of them, but teams can optionally use the one that only has the theme they need.
+
+It is still recommended to set defaultTheme with this option, as any missing variables will be merged with the default.
 
 ### Usage
 
@@ -285,8 +287,8 @@ const config = {
 postcss([
   require('postcss-themed')({
     config,
-    defaultTheme: 'light',
-    forceSingleTheme: true
+    defaultTheme: 'default',
+    forceSingleTheme: 'chair'
   })
 ]);
 ```
@@ -311,7 +313,7 @@ postcss([
 }
 
 .dark {
-  --color: darkpurple;
+  --color: dark-purple;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -317,8 +317,52 @@ postcss([
 }
 ```
 
-As you can see in the above example, the second theme is completely ignored.
-If only a light theme is specified, we don't even need to specify CSS variables to add the theme.
+As you can see in the above example, only one theme will be generated using this option.
+
+### optimizeSingleTheme
+
+This option should only be used in conjunction with `forceSingleTheme`.
+By default `forceSingleTheme` will always add CSS variables, since many users still want to be able to modify and override them.
+However, if you are not going to be modifying them, we can optimize the single theme further by removing variables when possible.
+If only a light theme is specified, this config option will just do in-place replacement of the theme variables.
+
+### Usage
+
+```js
+const config = {
+  default: {
+    color: 'purple'
+  },
+  chair: {
+    color: 'beige'
+  }
+};
+
+postcss([
+  require('postcss-themed')({
+    config,
+    defaultTheme: 'default',
+    forceSingleTheme: 'chair',
+    optimizeSingleTheme: true
+  })
+]);
+```
+
+**Input**
+
+```css
+.test {
+  color: @theme color;
+}
+```
+
+**Output**
+
+```css
+.test {
+  color: beige;
+}
+```
 
 ## Debug
 

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -194,7 +194,39 @@ it('Produces a single theme with dark mode if default has it', () => {
   );
 });
 
-it('Produces a single theme without variables if possible', () => {
+it('Produces a single theme with variables by default', () => {
+  const config = {
+    default: {
+      color: 'purple'
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+      }
+
+      :root {
+        --color: teal;
+      }
+    `,
+    {
+      config,
+      forceSingleTheme: 'mint'
+    }
+  );
+});
+
+it('Optimizes single theme by removing variables', () => {
   const config = {
     default: {
       color: 'purple'
@@ -217,7 +249,8 @@ it('Produces a single theme without variables if possible', () => {
     `,
     {
       config,
-      forceSingleTheme: 'mint'
+      forceSingleTheme: 'mint',
+      optimizeSingleTheme: true
     }
   );
 });

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -148,13 +148,12 @@ it('Produces a single theme', () => {
     `,
     {
       config,
-      defaultTheme: 'chair',
-      forceSingleTheme: true
+      forceSingleTheme: 'chair'
     }
   );
 });
 
-it('Produces a single theme without variables if possible', () => {
+it('Produces a single theme with dark mode if default has it', () => {
   const config = {
     default: {
       light: {
@@ -177,13 +176,48 @@ it('Produces a single theme without variables if possible', () => {
     `,
     `
       .test {
+        color: var(--color);
+      }
+
+      :root {
+        --color: teal;
+      }
+
+      .dark {
+        --color: black;
+      }
+    `,
+    {
+      config,
+      forceSingleTheme: 'mint'
+    }
+  );
+});
+
+it('Produces a single theme without variables if possible', () => {
+  const config = {
+    default: {
+      color: 'purple'
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
         color: teal;
       }
     `,
     {
       config,
-      defaultTheme: 'mint',
-      forceSingleTheme: true
+      forceSingleTheme: 'mint'
     }
   );
 });

--- a/__tests__/precedence.test.ts
+++ b/__tests__/precedence.test.ts
@@ -146,7 +146,43 @@ it('Merges missing variables from single theme', () => {
   );
 });
 
-it('Merges single theme but omits variables when possible', () => {
+it('Merges single theme but leaves variables by default', () => {
+  const config = {
+    default: {
+      color: 'red',
+      bgColor: 'orange'
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+        background-color: @theme bgColor;
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+        background-color: var(--bgColor);
+      }
+
+      :root {
+        --color: teal;
+        --bgColor: orange;
+      }
+    `,
+    {
+      config,
+      forceSingleTheme: 'mint'
+    }
+  );
+});
+
+it('Merges single theme but omits variables when optimized', () => {
   const config = {
     default: {
       color: 'red',
@@ -172,7 +208,8 @@ it('Merges single theme but omits variables when possible', () => {
     `,
     {
       config,
-      forceSingleTheme: 'mint'
+      forceSingleTheme: 'mint',
+      optimizeSingleTheme: true
     }
   );
 });

--- a/__tests__/precedence.test.ts
+++ b/__tests__/precedence.test.ts
@@ -98,3 +98,81 @@ it('Overrides dark themes from default', () => {
     }
   );
 });
+
+it('Merges missing variables from single theme', () => {
+  const config = {
+    default: {
+      light: {
+        color: 'red',
+        bgColor: 'orange'
+      },
+      dark: {
+        color: 'blue',
+        bgColor: 'magenta'
+      }
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+        background-color: @theme bgColor;
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+        background-color: var(--bgColor);
+      }
+
+      :root {
+        --color: teal;
+        --bgColor: orange;
+      }
+      
+      .dark {
+        --color: blue;
+        --bgColor: magenta;
+      }
+    `,
+    {
+      config,
+      forceSingleTheme: 'mint'
+    }
+  );
+});
+
+it('Merges single theme but omits variables when possible', () => {
+  const config = {
+    default: {
+      color: 'red',
+      bgColor: 'orange'
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+        background-color: @theme bgColor;
+      }
+    `,
+    `
+      .test {
+        color: teal;
+        background-color: orange;
+      }
+    `,
+    {
+      config,
+      forceSingleTheme: 'mint'
+    }
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,10 @@ export interface PostcssThemeOptions {
   forceEmptyThemeSelectors?: boolean;
   /** The name of the default theme */
   defaultTheme?: string;
+  /** Attempt to substitute only a single theme */
+  forceSingleTheme?: string;
   /** Transform CSS variable names similar to CSS-Modules */
   modules?: string | ScopedNameFunction;
-  /** Determines if we want to use all themes or individual themes */
-  forceSingleTheme?: boolean;
 }
 
 /** Get the theme variable name from a string */
@@ -268,7 +268,7 @@ const legacyTheme = (
 ) => {
   const {
     defaultTheme = 'default',
-    forceSingleTheme = false,
+    forceSingleTheme = undefined,
     forceEmptyThemeSelectors
   } = options;
   let newRules: postcss.Rule[] = [];
@@ -382,6 +382,19 @@ const hasDarkMode = (theme: Theme) =>
     Object.keys(theme.dark).length > 0 && Object.keys(theme.light).length > 0
   );
 
+/** Merge a given theme with a base theme */
+const mergeConfigs = (theme: LightDarkTheme, defaultTheme: LightDarkTheme) => {
+  const merged = defaultTheme;
+
+  for (const [colorScheme, values] of Object.entries(theme)) {
+    for (const [key, value] of Object.entries(values)) {
+      merged[colorScheme as ColorScheme][key] = value;
+    }
+  }
+
+  return merged;
+};
+
 /** Accomplish theming by creating CSS variable overrides  */
 const modernTheme = (
   root: postcss.Root,
@@ -391,7 +404,7 @@ const modernTheme = (
 ) => {
   const usage = new Set<string>();
   const defaultTheme = options.defaultTheme || 'default';
-  const singleTheme = options.forceSingleTheme || false;
+  const singleTheme = options.forceSingleTheme || undefined;
   const resourcePath = root.source ? root.source.input.file : '';
   const localize = getLocalizeFunction(options.modules, resourcePath);
 
@@ -401,6 +414,26 @@ const modernTheme = (
   const hasRootDarkMode =
     defaultThemeConfig && hasDarkMode(defaultThemeConfig[1]);
 
+  // For single theme mode, we need to handle themes that may be incomplete
+  // In that case, we merge the theme with default so all variables are present
+  const singleThemeConfig = Object.entries(componentConfig).find(
+    ([theme]) => theme === singleTheme
+  );
+
+  let mergedSingleThemeConfig = defaultThemeConfig
+    ? defaultThemeConfig[1]
+    : { light: {}, dark: {} };
+
+  if (defaultThemeConfig && singleThemeConfig && defaultTheme !== singleTheme) {
+    mergedSingleThemeConfig = mergeConfigs(
+      singleThemeConfig[1],
+      defaultThemeConfig[1]
+    );
+  }
+
+  const hasMergedDarkMode =
+    mergedSingleThemeConfig && hasDarkMode(mergedSingleThemeConfig);
+
   // 1. Walk each declaration and replace theme vars with CSS vars
   root.walkRules(rule => {
     rule.selector = replaceThemeRoot(rule.selector);
@@ -408,12 +441,14 @@ const modernTheme = (
     rule.walkDecls(decl => {
       while (decl.value.includes('@theme')) {
         const key = parseThemeKey(decl.value);
-        if (singleTheme && !hasRootDarkMode && defaultThemeConfig) {
+        if (singleTheme && !hasMergedDarkMode) {
           // If we are only building a single theme with light mode, just insert the value
-          decl.value = replaceTheme(
-            decl.value,
-            defaultThemeConfig[1].light[key]
-          );
+          if (mergedSingleThemeConfig.light[key]) {
+            decl.value = replaceTheme(
+              decl.value,
+              mergedSingleThemeConfig.light[key]
+            );
+          }
         } else {
           decl.value = replaceTheme(decl.value, `var(--${localize(key)})`);
         }
@@ -440,16 +475,16 @@ const modernTheme = (
   if (singleTheme) {
     const rules: (postcss.Rule | undefined)[] = [];
 
-    if (hasRootDarkMode && defaultThemeConfig) {
+    if (hasMergedDarkMode) {
       rules.push(
         createModernTheme(
           ':root',
-          filterUsed('light', defaultTheme, defaultThemeConfig[1]),
+          filterUsed('light', singleTheme, mergedSingleThemeConfig),
           localize
         ),
         createModernTheme(
           '.dark',
-          filterUsed('dark', defaultTheme, defaultThemeConfig[1]),
+          filterUsed('dark', singleTheme, mergedSingleThemeConfig),
           localize
         )
       );


### PR DESCRIPTION
# What Changed

My single theme support wasn't merging the config with default. If you had a _partial_ single theme with a more complete default, you would be missing some necessary variables. Now the two configurations are merged, so everything should override as expected.

This is a breaking change, because it changes the forceSingleTheme option to be a `string` instead of a `boolean`. Previously we were using the default theme, but we need to know the actual default still.

# Why

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
