### PR TITLE
optimizeSingleTheme: Detect missing keys and provide warning.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -451,6 +451,14 @@ const modernTheme = (
               decl.value,
               mergedSingleThemeConfig.light[key]
             );
+          } else {
+            root.warn(
+              root.toResult(),
+              `Could not find key ${key} in theme configuration. Removing declaration.`,
+              { node: decl }
+            );
+            decl.remove();
+            break;
           }
         } else {
           decl.value = replaceTheme(decl.value, `var(--${localize(key)})`);


### PR DESCRIPTION
# What Changed

We have a while loop that checks for all @themes being removed from a declaration, however when in optimize mode if there was no key I was not replacing the theme. This led to an infinite loop.

My change adds a warning and removes the invalid declaration if this is encountered.

# Why

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
