### PR TITLE
handle missing space in theme usage

### DIFF
--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -281,6 +281,34 @@ it("doesn't hang on $Variable", () => {
   );
 });
 
+it("doesn't hang on missing space", () => {
+  const config = {
+    default: {
+      color: 'purple'
+    },
+    mint: {
+      color: 'teal'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @themecolor;
+      }
+    `,
+    `
+      .test {
+        color: var(--color, teal);
+      }
+    `,
+    {
+      config,
+      forceSingleTheme: 'mint'
+    }
+  );
+});
+
 
 it('Produces a single theme with variables by default with inlineRootThemeVariables off', () => {
   const config = {

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import postcss from 'postcss';
 
 import { run } from './test-utils';
 
@@ -281,7 +282,7 @@ it("doesn't hang on $Variable", () => {
   );
 });
 
-it("doesn't hang on missing space", () => {
+it('should error on missing space', () => {
   const config = {
     default: {
       color: 'purple'
@@ -306,9 +307,12 @@ it("doesn't hang on missing space", () => {
       config,
       forceSingleTheme: 'mint'
     }
-  );
+  ).catch(e => {
+    expect(e.message).toEqual(
+      'postcss-themed: <css input>:3:16: Invalid @theme usage: @themecolor'
+    );
+  });
 });
-
 
 it('Produces a single theme with variables by default with inlineRootThemeVariables off', () => {
   const config = {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { PostcssThemeConfig, PostcssStrictThemeConfig, Theme } from '../types';
 
-const THEME_USAGE_REGEX = /@theme\s*\$?([a-zA-Z-_0-9]+)/;
+const THEME_USAGE_REGEX = /@theme \$?([a-zA-Z-_0-9]+)/;
 
 /** Get the theme variable name from a string */
 export const parseThemeKey = (value: string) => {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,16 +1,19 @@
 import path from 'path';
-import { PostcssThemeConfig, PostcssStrictThemeConfig, Theme } from "../types";
+
+import { PostcssThemeConfig, PostcssStrictThemeConfig, Theme } from '../types';
+
+const THEME_USAGE_REGEX = /@theme\s*\$?([a-zA-Z-_0-9]+)/;
 
 /** Get the theme variable name from a string */
 export const parseThemeKey = (value: string) => {
-  const key = value.match(/@theme \$?([a-zA-Z-_0-9]+)/);
+  const key = value.match(THEME_USAGE_REGEX);
   return key ? key[1] : '';
-}
+};
 
 /** Replace a theme variable reference with a value */
 export const replaceTheme = (value: string, replace: string) => {
-  return value.replace(/@theme \$?([a-zA-Z-_0-9]+)/, replace);
-}
+  return value.replace(THEME_USAGE_REGEX, replace);
+};
 
 /** Get the location of the theme file */
 export function getThemeFilename(cssFile: string) {
@@ -22,12 +25,14 @@ export const replaceThemeRoot = (selector: string) =>
   selector.replace(/:theme-root\((\S+)\)/g, '$1').replace(/:theme-root/g, '');
 
 /** Make a SimpleTheme into a LightDarkTheme */
-export const normalizeTheme = (config: PostcssThemeConfig | {}): PostcssStrictThemeConfig => {
+export const normalizeTheme = (
+  config: PostcssThemeConfig | {}
+): PostcssStrictThemeConfig => {
   return Object.assign(
     {},
     ...Object.entries(config).map(([theme, themeConfig]) => {
       if ('light' in themeConfig && 'dark' in themeConfig) {
-          return { [theme]: themeConfig };
+        return { [theme]: themeConfig };
       }
 
       return { [theme]: { light: themeConfig, dark: {} } };
@@ -40,4 +45,3 @@ export const hasDarkMode = (theme: Theme) =>
   Boolean(
     Object.keys(theme.dark).length > 0 && Object.keys(theme.light).length > 0
   );
-

--- a/src/modern/index.ts
+++ b/src/modern/index.ts
@@ -180,8 +180,10 @@ export const modernTheme = (
               mergedSingleThemeConfig.light[key]
             })`
           );
-        } else {
+        } else if (key) {
           decl.value = replaceTheme(decl.value, `var(--${localize(key)})`);
+        } else {
+          throw decl.error(`Invalid @theme usage: ${decl.value}`, { word: decl.value })
         }
       }
     });


### PR DESCRIPTION
# What Changed

if there was a missing space when using `@theme variable` the build would hang

Todo:

- [x] Add tests


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `2.2.4-canary.40.506`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
