### PR TITLE
Allow one theme to extend from another

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Will create class overrides for legacy browsers and use CSS variables for modern
 
 :rocket: Supports scoping CSS Variable names to mitigate conflicts
 
+:rocket: Themes can extend other themes
+
 [postcss]: https://github.com/postcss/postcss
 
 ## Contributing
@@ -89,7 +91,7 @@ See [PostCSS] docs for examples for your environment.
 
 ### Using Theme Variables
 
-**Input**
+**Input:**
 
 ```css
 .foo {
@@ -98,7 +100,7 @@ See [PostCSS] docs for examples for your environment.
 }
 ```
 
-**Output**
+**Output:**
 
 ```css
 .foo {
@@ -115,7 +117,7 @@ See [PostCSS] docs for examples for your environment.
 
 Define a component level theme in either commonjs or typescript. A file names `themes.(js|ts)` must be co-located with the themeable CSS file.
 
-**themes.js**
+**themes.js:**
 
 ```js
 module.exports = (theme) => ({
@@ -128,7 +130,7 @@ module.exports = (theme) => ({
 });
 ```
 
-**themes.ts**
+**themes.ts:**
 
 ```js
 import { Theme } from '@your/themes';
@@ -165,11 +167,63 @@ postcss([
 
 Now you can use `@theme border` in your CSS file.
 
-### Theming Root class
+### Theme Extension
+
+Any theme can extend another theme.
+This is useful when you are defining a child theme that customizes some stuff but in general adopts most of the styling of another theme.
+
+**Config:**
+
+```js
+const config = {
+  default: {
+    color: 'white',
+    background: 'black'
+  },
+  myTheme: {
+    color: 'purple',
+    background: 'green'
+  },
+  myChildTheme: {
+    extends: 'myTheme',
+    background: 'red'
+  }
+};
+```
+
+**Input:**
+
+```css
+.test {
+  color: @theme color;
+  background: @theme background;
+}
+```
+
+**Output:**
+
+```css
+.test {
+  color: var(--color, white);
+  background: var(--background, black);
+}
+
+.myTheme {
+  --color: purple;
+  --background: green;
+}
+
+.myChildTheme {
+  --color: purple;
+  --background: red;
+}
+```
+
+### Theming Root class (LEGACY ONLY)
 
 Only needed when targeting legacy environments that do not support CSS Variables.
 
-**Input**
+**Input:**
 
 ```css
 :theme-root(.foo) {
@@ -179,7 +233,7 @@ Only needed when targeting legacy environments that do not support CSS Variables
 
 or by nesting
 
-**Input**
+**Input:**
 
 ```css
 :theme-root {
@@ -189,7 +243,7 @@ or by nesting
 }
 ```
 
-**Output**
+**Output:**
 
 ```css
 .foo {
@@ -202,7 +256,7 @@ or by nesting
 
 ## Options
 
-### modules
+### `modules`
 
 This plugin also support scoping your CSS Variable names in a very similar way to CSS Modules. This option should be used when targeting browsers with css variables to avoid name collisions.
 
@@ -266,11 +320,11 @@ postcss([
 ]);
 ```
 
-### defaultTheme
+### `defaultTheme`
 
 An optional parameter to change the name of the _default_ theme (where no extra classes are added to the selector). It defaults to `default`, and also corresponds to the only required key in your `theme.ts` files.
 
-### forceEmptyThemeSelectors - only legacy
+### `forceEmptyThemeSelectors` - only legacy
 
 By default this plugin will not produce class names for theme that have no component level configuration if there are no styles. (ex: you have 3 themes but your component only uses 1, then only 1 extra set of classnames is produced).
 
@@ -284,7 +338,7 @@ postcss([
 ]);
 ```
 
-### forceSingleTheme
+### `forceSingleTheme`
 
 This is a niche option which only inserts a single theme.
 At first glance, this may seem strange because this plugin primarily allows you to support _many_ themes in a _single_ CSS file.
@@ -293,7 +347,7 @@ In practice, we use this to generate extra CSS files for teams that only need a 
 
 It is still recommended to set defaultTheme with this option, as any missing variables will be merged with the default.
 
-### Usage
+**Config:**
 
 ```js
 const config = {
@@ -324,7 +378,7 @@ postcss([
 ]);
 ```
 
-**Input**
+**Input:**
 
 ```css
 .test {
@@ -332,7 +386,7 @@ postcss([
 }
 ```
 
-**Output**
+**Output:**
 
 ```css
 .test {
@@ -350,14 +404,14 @@ postcss([
 
 As you can see in the above example, only one theme will be generated using this option.
 
-### optimizeSingleTheme
+### `optimizeSingleTheme`
 
 This option should only be used in conjunction with `forceSingleTheme`.
 By default `forceSingleTheme` will always add CSS variables, since many users still want to be able to modify and override them.
 However, if you are not going to be modifying them, we can optimize the single theme further by removing variables when possible.
 If only a light theme is specified, this config option will just do in-place replacement of the theme variables.
 
-### Usage
+**Config:**
 
 ```js
 const config = {
@@ -379,7 +433,7 @@ postcss([
 ]);
 ```
 
-**Input**
+**Input:**
 
 ```css
 .test {
@@ -387,7 +441,7 @@ postcss([
 }
 ```
 
-**Output**
+**Output:**
 
 ```css
 .test {
@@ -431,6 +485,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/__tests__/common.test.ts
+++ b/__tests__/common.test.ts
@@ -31,6 +31,38 @@ it('should be able to extend a simple theme', () => {
   });
 });
 
+it('should be able to extend a simple theme', () => {
+  expect(
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          light: { color: 'blue' },
+          dark: { color: 'green' }
+        },
+        myChildTheme: {
+          extends: 'myTheme'
+        }
+      })
+    )
+  ).toStrictEqual({
+    default: {
+      light: { color: 'red' },
+      dark: {}
+    },
+    myTheme: {
+      light: { color: 'blue' },
+      dark: { color: 'green' }
+    },
+    myChildTheme: {
+      light: { color: 'blue' },
+      dark: { color: 'green' }
+    }
+  });
+});
+
 it('should be able to extend a dark/light theme from root', () => {
   expect(
     resolveThemeExtension({
@@ -158,7 +190,7 @@ it('should error on unknown themes', () => {
   ).toThrow("Theme to extend from not found! 'myThemes'");
 });
 
-it('should when extending itself', () => {
+it('should error when extending itself', () => {
   expect(() =>
     resolveThemeExtension(
       normalizeTheme({
@@ -173,7 +205,7 @@ it('should when extending itself', () => {
   ).toThrow("A theme cannot extend itself! 'myTheme' extends 'myTheme'");
 });
 
-it('should when cycles detected', () => {
+it('should error when cycles detected', () => {
   expect(() =>
     resolveThemeExtension({
       default: {
@@ -196,7 +228,7 @@ it('should when cycles detected', () => {
   );
 });
 
-it('should when cycles detected - subthemes', () => {
+it('should error when cycles detected - subthemes', () => {
   expect(() =>
     resolveThemeExtension(
       normalizeTheme({
@@ -216,8 +248,7 @@ it('should when cycles detected - subthemes', () => {
   );
 });
 
-
-it('should when cycles detected - complicated', () => {
+it('should error when cycles detected - complicated', () => {
   expect(() =>
     resolveThemeExtension(
       normalizeTheme({

--- a/__tests__/common.test.ts
+++ b/__tests__/common.test.ts
@@ -1,0 +1,247 @@
+import { resolveThemeExtension, normalizeTheme } from '../src/common';
+
+it('should be able to extend a simple theme', () => {
+  expect(
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          color: 'blue'
+        },
+        myChildTheme: {
+          extends: 'myTheme'
+        }
+      })
+    )
+  ).toStrictEqual({
+    default: {
+      light: { color: 'red' },
+      dark: {}
+    },
+    myTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    },
+    myChildTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    }
+  });
+});
+
+it('should be able to extend a dark/light theme from root', () => {
+  expect(
+    resolveThemeExtension({
+      default: {
+        light: { color: 'white' },
+        dark: { color: 'black' }
+      },
+      myTheme: {
+        light: { color: 'blue' },
+        dark: { color: 'red' }
+      },
+      myChildTheme: {
+        extends: 'myTheme',
+        light: {},
+        dark: {}
+      }
+    })
+  ).toStrictEqual({
+    default: {
+      light: { color: 'white' },
+      dark: { color: 'black' }
+    },
+    myTheme: {
+      light: { color: 'blue' },
+      dark: { color: 'red' }
+    },
+    myChildTheme: {
+      light: { color: 'blue' },
+      dark: { color: 'red' }
+    }
+  });
+});
+
+it('should be able to extend a theme that extends another theme', () => {
+  expect(
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          color: 'blue'
+        },
+        myChildTheme: {
+          extends: 'myTheme'
+        },
+        myOtherChildTheme: {
+          extends: 'myChildTheme'
+        }
+      })
+    )
+  ).toStrictEqual({
+    default: {
+      light: { color: 'red' },
+      dark: {}
+    },
+    myTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    },
+    myChildTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    },
+    myOtherChildTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    }
+  });
+});
+
+it('should be able to extend a theme that extends another theme - out of order', () => {
+  expect(
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          color: 'blue'
+        },
+        myOtherChildTheme: {
+          extends: 'myChildTheme'
+        },
+        myChildTheme: {
+          extends: 'myTheme'
+        }
+      })
+    )
+  ).toStrictEqual({
+    default: {
+      light: { color: 'red' },
+      dark: {}
+    },
+    myTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    },
+    myChildTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    },
+    myOtherChildTheme: {
+      light: { color: 'blue' },
+      dark: {}
+    }
+  });
+});
+
+it('should error on unknown themes', () => {
+  expect(() =>
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          color: 'blue'
+        },
+        myChildTheme: {
+          extends: 'myThemes'
+        }
+      })
+    )
+  ).toThrow("Theme to extend from not found! 'myThemes'");
+});
+
+it('should when extending itself', () => {
+  expect(() =>
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          extends: 'myTheme'
+        }
+      })
+    )
+  ).toThrow("A theme cannot extend itself! 'myTheme' extends 'myTheme'");
+});
+
+it('should when cycles detected', () => {
+  expect(() =>
+    resolveThemeExtension({
+      default: {
+        light: { color: 'white' },
+        dark: { color: 'black' }
+      },
+      myTheme: {
+        extends: 'myChildTheme',
+        light: { color: 'blue' },
+        dark: {}
+      },
+      myChildTheme: {
+        extends: 'myTheme',
+        light: {},
+        dark: {}
+      }
+    })
+  ).toThrow(
+    "Circular theme extension found! 'myTheme' => 'myChildTheme' => 'myTheme'"
+  );
+});
+
+it('should when cycles detected - subthemes', () => {
+  expect(() =>
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        myTheme: {
+          extends: 'myChildTheme'
+        },
+        myChildTheme: {
+          extends: 'myTheme'
+        }
+      })
+    )
+  ).toThrow(
+    "Circular theme extension found! 'myTheme' => 'myChildTheme' => 'myTheme'"
+  );
+});
+
+
+it('should when cycles detected - complicated', () => {
+  expect(() =>
+    resolveThemeExtension(
+      normalizeTheme({
+        default: {
+          color: 'red'
+        },
+        one: {
+          extends: 'five'
+        },
+        two: {
+          extends: 'one'
+        },
+        three: {
+          extends: 'two'
+        },
+        four: {
+          extends: 'three'
+        },
+        five: {
+          extends: 'four'
+        }
+      })
+    )
+  ).toThrow(
+    "Circular theme extension found! 'one' => 'five' => 'four' => 'three' => 'two' => 'one'"
+  );
+});

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto';
-import postcss from 'postcss';
 
 import { run } from './test-utils';
 
@@ -647,6 +646,90 @@ it('Some variables show inline and some show in root', () => {
 
       .mint {
         --color: teal
+      }
+    `,
+    {
+      config
+    }
+  );
+});
+
+it('can extend another theme', () => {
+  const config = {
+    default: {
+      color: 'purple'
+    },
+    turbotax: {
+      color: 'teal'
+    },
+    mytt: {
+      extends: 'turbotax'
+    }
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: var(--color, purple);
+      }
+
+      .turbotax {
+        --color: teal;
+      }
+
+      .mytt {
+        --color: teal;
+      }
+    `,
+    {
+      config
+    }
+  );
+});
+
+
+it('can extend another theme that extends a theme', () => {
+  const config = {
+    default: {
+      color: 'purple'
+    },
+    turbotax: {
+      color: 'teal'
+    },
+    mytt: {
+      extends: 'turbotax'
+    },
+    ttlive: {
+      extends: 'mytt'
+    },
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+      }
+    `,
+    `
+      .test {
+        color: var(--color, purple);
+      }
+
+      .turbotax {
+        --color: teal;
+      }
+
+      .mytt {
+        --color: teal;
+      }
+
+      .ttlive {
+        --color: teal;
       }
     `,
     {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -42,6 +42,20 @@ export const normalizeTheme = (
         return { [theme]: themeConfig };
       }
 
+      if (themeConfig.extends) {
+        const configWithoutExtends = { ...themeConfig };
+
+        delete configWithoutExtends.extends;
+
+        return {
+          [theme]: {
+            extends: themeConfig.extends,
+            light: configWithoutExtends,
+            dark: {}
+          }
+        };
+      }
+
       return { [theme]: { light: themeConfig, dark: {} } };
     })
   );
@@ -91,6 +105,17 @@ export const resolveThemeExtension = (
   const resolveSubTheme = (theme: string) => {
     const subConfig = { ...config };
     delete subConfig[theme];
+
+    Object.keys(subConfig).forEach(t => {
+      if (
+        subConfig[t].extends === theme ||
+        subConfig[t].light.extends === theme ||
+        subConfig[t].dark.extends === theme
+      ) {
+        delete subConfig[t];
+      }
+    });
+
     resolveThemeExtension(subConfig);
   };
 
@@ -126,7 +151,7 @@ export const resolveThemeExtension = (
       checkExtendSelf(theme, themeConfig.extends);
       checkCycles(theme);
 
-      if (!config[themeConfig.extends]) {
+      if (config[themeConfig.extends]) {
         resolveSubTheme(theme);
       }
 

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,6 +1,13 @@
 import path from 'path';
+import merge from 'deepmerge';
 
-import { PostcssThemeConfig, PostcssStrictThemeConfig, Theme } from '../types';
+import {
+  PostcssThemeConfig,
+  PostcssStrictThemeConfig,
+  Theme,
+  LightDarkTheme,
+  ColorScheme
+} from '../types';
 
 const THEME_USAGE_REGEX = /@theme \$?([a-zA-Z-_0-9]+)/;
 
@@ -38,6 +45,110 @@ export const normalizeTheme = (
       return { [theme]: { light: themeConfig, dark: {} } };
     })
   );
+};
+
+/** Resolve any "extends" fields for a theme */
+export const resolveThemeExtension = (
+  config: PostcssStrictThemeConfig
+): PostcssStrictThemeConfig => {
+  const checkExtendSelf = (theme: string, extendsTheme: string) => {
+    if (extendsTheme === theme) {
+      throw new Error(
+        `A theme cannot extend itself! '${theme}' extends '${extendsTheme}'`
+      );
+    }
+  };
+
+  const checkThemeExists = (extendsTheme: string) => {
+    if (!config[extendsTheme]) {
+      throw new Error(`Theme to extend from not found! '${extendsTheme}'`);
+    }
+  };
+
+  const checkCycles = (theme: string, colorScheme?: ColorScheme) => {
+    const chain = [theme];
+    let currentTheme = colorScheme
+      ? config[theme][colorScheme].extends
+      : config[theme].extends;
+
+    while (currentTheme) {
+      if (chain.includes(currentTheme)) {
+        chain.push(currentTheme);
+        throw new Error(
+          `Circular theme extension found! ${chain
+            .map(i => `'${i}'`)
+            .join(' => ')}`
+        );
+      }
+
+      chain.push(currentTheme);
+      currentTheme = colorScheme
+        ? config[currentTheme][colorScheme].extends
+        : config[currentTheme].extends;
+    }
+  };
+
+  const resolveSubTheme = (theme: string) => {
+    const subConfig = { ...config };
+    delete subConfig[theme];
+    resolveThemeExtension(subConfig);
+  };
+
+  const resolveColorSchemeTheme = (
+    themeConfig: LightDarkTheme,
+    theme: string,
+    colorScheme: ColorScheme
+  ) => {
+    let extras = {};
+
+    if (themeConfig[colorScheme].extends) {
+      checkThemeExists(themeConfig[colorScheme].extends);
+      checkExtendSelf(theme, themeConfig[colorScheme].extends);
+      checkCycles(theme, colorScheme);
+
+      if (config[themeConfig[colorScheme].extends][colorScheme].extends) {
+        resolveSubTheme(theme);
+      }
+
+      extras = config[themeConfig[colorScheme].extends][colorScheme];
+      delete themeConfig[colorScheme].extends;
+    }
+
+    return extras;
+  };
+
+  Object.entries(config).forEach(([theme, themeConfig]) => {
+    let lightExtras = {};
+    let darkExtras = {};
+
+    if (themeConfig.extends) {
+      checkThemeExists(themeConfig.extends);
+      checkExtendSelf(theme, themeConfig.extends);
+      checkCycles(theme);
+
+      if (!config[themeConfig.extends]) {
+        resolveSubTheme(theme);
+      }
+
+      const newConfig = merge(config[themeConfig.extends], themeConfig);
+      delete themeConfig.extends;
+      themeConfig.light = newConfig.light;
+      themeConfig.dark = newConfig.dark;
+    }
+
+    if (themeConfig.light.extends) {
+      lightExtras = resolveColorSchemeTheme(themeConfig, theme, 'light');
+    }
+
+    if (themeConfig.dark.extends) {
+      darkExtras = resolveColorSchemeTheme(themeConfig, theme, 'dark');
+    }
+
+    themeConfig.light = { ...lightExtras, ...themeConfig.light };
+    themeConfig.dark = { ...darkExtras, ...themeConfig.dark };
+  });
+
+  return config;
 };
 
 /** Determine if a theme has dark mode enabled */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,11 @@ import * as caniuse from 'caniuse-api';
 import browserslist from 'browserslist';
 import * as tsNode from 'ts-node';
 
-import { getThemeFilename, normalizeTheme, resolveThemeExtension } from './common';
+import {
+  getThemeFilename,
+  normalizeTheme,
+  resolveThemeExtension
+} from './common';
 import { modernTheme } from './modern';
 import { legacyTheme } from './legacy';
 import {
@@ -81,7 +85,7 @@ const themeFile = (options: PostcssThemeOptions = {}) => (
   );
   const mergedConfig = merge(globalConfig, componentConfig);
 
-  resolveThemeExtension(mergedConfig)
+  resolveThemeExtension(mergedConfig);
 
   if (caniuse.isSupported('css-variables', browserslist())) {
     modernTheme(root, mergedConfig, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as caniuse from 'caniuse-api';
 import browserslist from 'browserslist';
 import * as tsNode from 'ts-node';
 
-import { getThemeFilename, normalizeTheme } from './common';
+import { getThemeFilename, normalizeTheme, resolveThemeExtension } from './common';
 import { modernTheme } from './modern';
 import { legacyTheme } from './legacy';
 import {
@@ -80,6 +80,8 @@ const themeFile = (options: PostcssThemeOptions = {}) => (
     configForComponent(root.source.input.file, config, resolveTheme)
   );
   const mergedConfig = merge(globalConfig, componentConfig);
+
+  resolveThemeExtension(mergedConfig)
 
   if (caniuse.isSupported('css-variables', browserslist())) {
     modernTheme(root, mergedConfig, options);

--- a/src/modern/index.ts
+++ b/src/modern/index.ts
@@ -46,6 +46,10 @@ const mergeConfigs = (theme: LightDarkTheme, defaultTheme: LightDarkTheme) => {
   const merged = defaultTheme;
 
   for (const [colorScheme, values] of Object.entries(theme)) {
+    if (!values) {
+      continue
+    }
+
     for (const [key, value] of Object.entries(values)) {
       merged[colorScheme as ColorScheme][key] = value;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export type SimpleTheme = Record<string, string>;
 export type ColorScheme = 'light' | 'dark';
-export type LightDarkTheme = Record<ColorScheme, SimpleTheme>;
+export type LightDarkTheme = Record<ColorScheme, SimpleTheme> & Partial<Record<'extends', string>>;
 export type Theme = SimpleTheme | LightDarkTheme;
 
 export interface Config<T> {


### PR DESCRIPTION
# What Changed

See title

# Why

A lot of themes can be expressed as sub themes

Todo:

- [x] Add tests
- [x] Add docs


<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `2.3.0-canary.42.534`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
