### PR TITLE
Hot Reloading: Include Extension in Theme File Path

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import merge from 'deepmerge';
 
 import {
@@ -24,7 +25,12 @@ export const replaceTheme = (value: string, replace: string) => {
 
 /** Get the location of the theme file */
 export function getThemeFilename(cssFile: string) {
-  return path.join(path.dirname(cssFile), 'theme');
+  let themePath = path.join(path.dirname(cssFile), 'theme.ts');
+  if (!fs.existsSync(themePath)) {
+    themePath = path.join(path.dirname(cssFile), 'theme.js');
+  }
+
+  return themePath;
 }
 
 /** Remove :theme-root usage from a selector */


### PR DESCRIPTION
# What Changed

I changed the `getThemeFilename` function to include a file extension which was needed for hot reloading.

# Why

There was recently [a change](https://github.com/intuit/postcss-themed/pull/36/files) to add the theme file as a dependency for hot reloading. I was having trouble getting this working in a design system and started debugging what was going on. What I found was the hot reloading logic used `getThemeFilename` to add the theme file as a dependency. However, the `getThemeFilename` function was returning the filename without an extension.

```
my-ds/components/Component/src/theme
```

I think this works in [other parts ](https://github.com/intuit/postcss-themed/blob/master/src/index.ts#L49) of the project because `require` figures out the extension.

I edited node_modules and changed `getThemeFilename` to test for our default `ts` and `js` extensions, and my hot reloading started working. I'll test the change here with a canary.


Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn all-contributors add [name] [type]`) see https://github.com/all-contributors/all-contributors/blob/master/docs/cli/usage.md

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `2.4.1-canary.44.566`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
