### PR TITLE
add alternative theme usage syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ See [PostCSS] docs for examples for your environment.
   color: @theme color;
   border: @theme border-width solid @theme color;
 }
+
+/* OR */
+
+.foo {
+  color: theme('color');
+  border: theme('border-width') solid theme('color');
+}
 ```
 
 **Output:**

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -42,6 +42,37 @@ it('Creates a simple css variable based theme', () => {
   );
 });
 
+it('Can use alternative theme syntax', () => {
+  const config = {
+    default: {
+      color: 'purple',
+    },
+    mint: {
+      color: 'teal',
+    },
+  };
+
+  return run(
+    `
+      .test {
+        color: theme('color');
+      }
+    `,
+    `
+      .test {
+        color: var(--color, purple);
+      }
+
+      .mint {
+        --color: teal;
+      }
+    `,
+    {
+      config,
+    }
+  );
+});
+
 it('inlineRootThemeVariables false', () => {
   const config = {
     default: {
@@ -225,7 +256,7 @@ it('Produces a single theme with dark mode if default has it', () => {
   );
 });
 
-it('Don\'t produce extra variables for matching values', () => {
+it("Don't produce extra variables for matching values", () => {
   const config = {
     default: {
       light: {
@@ -234,7 +265,7 @@ it('Don\'t produce extra variables for matching values', () => {
       dark: {
         color: 'black',
       },
-    }
+    },
   };
 
   return run(
@@ -249,12 +280,12 @@ it('Don\'t produce extra variables for matching values', () => {
       }
     `,
     {
-      config
+      config,
     }
   );
 });
 
-it('Don\'t produce extra variables for matching values in theme', () => {
+it("Don't produce extra variables for matching values in theme", () => {
   const config = {
     default: {
       light: {
@@ -271,7 +302,7 @@ it('Don\'t produce extra variables for matching values in theme', () => {
       dark: {
         color2: 'black',
       },
-    }
+    },
   };
 
   return run(
@@ -286,12 +317,12 @@ it('Don\'t produce extra variables for matching values in theme', () => {
       }
     `,
     {
-      config
+      config,
     }
   );
 });
 
-it('Don\'t produce extra variables for matching values in theme', () => {
+it("Don't produce extra variables for matching values in theme", () => {
   const config = {
     default: {
       light: {
@@ -308,7 +339,7 @@ it('Don\'t produce extra variables for matching values in theme', () => {
       dark: {
         color: 'black',
       },
-    }
+    },
   };
 
   return run(
@@ -331,25 +362,25 @@ it('Don\'t produce extra variables for matching values in theme', () => {
       }
     `,
     {
-      config
+      config,
     }
   );
 });
 
-it('Don\'t included deep values in theme', () => {
+it("Don't included deep values in theme", () => {
   const config = {
     default: {
       // Component theme defines a "color" variable that clashes
       // with "color" object on themes
-      color: "red"
+      color: 'red',
     },
     someTheme: {
       // Theme doesn't set a "color" but get the "color" tokens
-      color:  {
+      color: {
         red: 'red2',
         green: 'green2',
-      }
-    }
+      },
+    },
   };
 
   return run(
@@ -364,7 +395,7 @@ it('Don\'t included deep values in theme', () => {
       }
     `,
     {
-      config
+      config,
     }
   );
 });
@@ -557,7 +588,35 @@ it('should error on missing space', () => {
     }
   ).catch((e) => {
     expect(e.message).toEqual(
-      'postcss-themed: <css input>:3:16: Invalid @theme usage: @themecolor'
+      'postcss-themed: <css input>:3:16: Invalid theme usage: @themecolor'
+    );
+  });
+});
+
+it('should error on invalid alt usage space', () => {
+  const config = {
+    default: {
+      color: 'purple',
+    },
+    mint: {
+      color: 'teal',
+    },
+  };
+
+  return run(
+    `
+      .test {
+        color: theme ('color');
+      }
+    `,
+    '',
+    {
+      config,
+      forceSingleTheme: 'mint',
+    }
+  ).catch((e) => {
+    expect(e.message).toEqual(
+      "postcss-themed: <css input>:3:16: Invalid theme usage: theme ('color')"
     );
   });
 });
@@ -787,34 +846,6 @@ it('scoped variable names with default function', () => {
     {
       config,
       modules: 'default',
-    }
-  );
-});
-
-it('Wrong key mentioned in theme configuration', () => {
-  const config = {
-    default: {
-      color: 'purple',
-    },
-    light: {
-      color: 'white',
-    },
-  };
-
-  return run(
-    `
-      .test {
-        background-color: @theme background-color;
-      }
-    `,
-    `
-      .test {
-      }
-    `,
-    {
-      config,
-      forceSingleTheme: 'mint',
-      optimizeSingleTheme: true,
     }
   );
 });

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -73,6 +73,39 @@ it('Can use alternative theme syntax', () => {
   );
 });
 
+it('Can use alternative theme syntax - multiline', () => {
+  const config = {
+    default: {
+      color: 'purple',
+    },
+    mint: {
+      color: 'teal',
+    },
+  };
+
+  return run(
+    `
+      .test {
+        color: theme(
+          'color'
+        );
+      }
+    `,
+    `
+      .test {
+        color: var(--color, purple);
+      }
+
+      .mint {
+        --color: teal;
+      }
+    `,
+    {
+      config,
+    }
+  );
+});
+
 it('inlineRootThemeVariables false', () => {
   const config = {
     default: {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../types';
 
 const THEME_USAGE_REGEX = /@theme\s+\$?([a-zA-Z-_0-9.]+)/;
-const ALT_THEME_USAGE_REGEX = /theme\(['"]([a-zA-Z-_0-9.]+)['"]\)/;
+const ALT_THEME_USAGE_REGEX = /theme\(\s*['"]([a-zA-Z-_0-9.]+)['"]\s*\)/;
 
 /** Get the theme variable name from a string */
 export const parseThemeKey = (value: string) => {
@@ -42,7 +42,7 @@ export const replaceTheme = (value: string, replace: string) => {
 /** Get the location of the theme file */
 export function getThemeFilename(cssFile: string) {
   let themePath = path.join(path.dirname(cssFile), 'theme.ts');
-  
+
   if (!fs.existsSync(themePath)) {
     themePath = path.join(path.dirname(cssFile), 'theme.js');
   }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -11,21 +11,38 @@ import {
 } from '../types';
 
 const THEME_USAGE_REGEX = /@theme\s+\$?([a-zA-Z-_0-9.]+)/;
+const ALT_THEME_USAGE_REGEX = /theme\(['"]([a-zA-Z-_0-9.]+)['"]\)/;
 
 /** Get the theme variable name from a string */
 export const parseThemeKey = (value: string) => {
-  const key = value.match(THEME_USAGE_REGEX);
-  return key ? key[1] : '';
+  let key = value.match(THEME_USAGE_REGEX);
+
+  if (key) {
+    return key[1];
+  }
+
+  key = value.match(ALT_THEME_USAGE_REGEX);
+
+  if (key) {
+    return key[1];
+  }
+
+  return '';
 };
 
 /** Replace a theme variable reference with a value */
 export const replaceTheme = (value: string, replace: string) => {
-  return value.replace(THEME_USAGE_REGEX, replace);
+  if (value.match(THEME_USAGE_REGEX)) {
+    return value.replace(THEME_USAGE_REGEX, replace);
+  }
+
+  return value.replace(ALT_THEME_USAGE_REGEX, replace);
 };
 
 /** Get the location of the theme file */
 export function getThemeFilename(cssFile: string) {
   let themePath = path.join(path.dirname(cssFile), 'theme.ts');
+  
   if (!fs.existsSync(themePath)) {
     themePath = path.join(path.dirname(cssFile), 'theme.js');
   }

--- a/src/legacy/index.ts
+++ b/src/legacy/index.ts
@@ -19,12 +19,14 @@ const replaceThemeVariables = (
   colorScheme: 'light' | 'dark' = 'light',
   defaultTheme = 'default'
 ) => {
-  const hasMultiple = (decl.value.match(/@theme/g) || []).length > 1;
+  const hasMultiple =
+    (decl.value.match(/@theme/g) || decl.value.match(/theme\(['"]/g) || [])
+      .length > 1;
+
+  let themeKey = parseThemeKey(decl.value);
 
   // Found a theme reference
-  while (decl.value.includes('@theme')) {
-    const themeKey = parseThemeKey(decl.value);
-
+  while (themeKey) {
     // Check for issues with theme
     try {
       const themeDefault: string = get(
@@ -47,6 +49,8 @@ const replaceThemeVariables = (
         plugin: 'postcss-themed',
       });
     }
+
+    themeKey = parseThemeKey(decl.value);
   }
 };
 
@@ -179,7 +183,7 @@ export const legacyTheme = (
     rule.walkDecls((decl) => {
       const { value } = decl;
 
-      if (value.includes('@theme')) {
+      if (parseThemeKey(value)) {
         themedDeclarations.push(decl.clone());
         // Replace defaults in original CSS rule
         replaceThemeVariables(


### PR DESCRIPTION
# What Changed

Add new `theme("VARIABLE_NAME")` syntax.

# Why

It is easier to read.

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `2.7.0-canary.53.684`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
