### PR TITLE
add ability to override color scheme classNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,20 @@ postcss([
 
 An optional parameter to change the name of the _default_ theme (where no extra classes are added to the selector). It defaults to `default`, and also corresponds to the only required key in your `theme.ts` files.
 
+### `lightClass` + `darkClass`
+
+Classes to apply to color scheme overrides.
+
+```js
+postcss([
+  require('postcss-themed')({
+    config,
+    lightClass: '.light-theme',
+    darkClass: '.dark-theme',
+  }),
+]);
+```
+
 ### `forceEmptyThemeSelectors` - only legacy
 
 By default this plugin will not produce class names for theme that have no component level configuration if there are no styles. (ex: you have 3 themes but your component only uses 1, then only 1 extra set of classnames is produced).

--- a/__tests__/modern.test.ts
+++ b/__tests__/modern.test.ts
@@ -207,6 +207,70 @@ it('Creates a simple css variable based theme with light and dark', () => {
   );
 });
 
+it('Can override dark and light class', () => {
+  const config = {
+    default: {
+      light: {
+        color: 'purple',
+      },
+      dark: {
+        color: 'black',
+      },
+    },
+
+    mint: {
+      color: 'teal',
+    },
+    chair: {
+      light: {
+        color: 'beige',
+      },
+      dark: {
+        color: 'darkpurple',
+      },
+    },
+  };
+
+  return run(
+    `
+      .test {
+        color: @theme color;
+        background-image: linear-gradient(to right, @theme color, @theme color)
+      }
+    `,
+    `
+      .test {
+        color: var(--color);
+        background-image: linear-gradient(to right, var(--color), var(--color))
+      }
+      :root {
+        --color: purple
+      }
+
+      .dark-theme {
+        --color: black
+      }
+
+      .mint.light-theme {
+        --color: teal
+      }
+
+      .chair.light-theme {
+        --color: beige
+      }
+
+      .chair.dark-theme {
+        --color: darkpurple
+      }
+    `,
+    {
+      config,
+      lightClass: '.light-theme',
+      darkClass: '.dark-theme',
+    }
+  );
+});
+
 it('Produces a single theme', () => {
   const config = {
     default: {

--- a/src/modern/index.ts
+++ b/src/modern/index.ts
@@ -113,6 +113,8 @@ export const modernTheme = (
   const singleTheme = options.forceSingleTheme || undefined;
   const optimizeSingleTheme = options.optimizeSingleTheme;
   const inlineRootThemeVariables = options.inlineRootThemeVariables ?? true;
+  const lightClass = options.lightClass || '.light';
+  const darkClass = options.darkClass || '.dark';
   const resourcePath = root.source ? root.source.input.file : '';
   const localize = (name: string) =>
     getLocalizeFunction(
@@ -278,7 +280,7 @@ export const modernTheme = (
     if (hasMergedDarkMode) {
       rules.push(
         createModernTheme(
-          '.dark',
+          darkClass,
           filterUsed('dark', mergedSingleThemeConfig),
           localize
         )
@@ -301,21 +303,25 @@ export const modernTheme = (
     if (theme === defaultTheme) {
       rules.push(addRootTheme(themeConfig));
       rules.push(
-        createModernTheme('.dark', filterUsed('dark', defaultTheme), localize)
+        createModernTheme(darkClass, filterUsed('dark', defaultTheme), localize)
       );
     } else if (hasDarkMode(themeConfig)) {
       rules.push(
         createModernTheme(
-          `.${theme}.light`,
+          `.${theme}${lightClass}`,
           filterUsed('light', theme),
           localize
         ),
-        createModernTheme(`.${theme}.dark`, filterUsed('dark', theme), localize)
+        createModernTheme(
+          `.${theme}${darkClass}`,
+          filterUsed('dark', theme),
+          localize
+        )
       );
     } else {
       rules.push(
         createModernTheme(
-          hasRootDarkMode ? `.${theme}.light` : `.${theme}`,
+          hasRootDarkMode ? `.${theme}${lightClass}` : `.${theme}`,
           filterUsed('light', theme),
           localize
         )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,10 @@ export type ScopedNameFunction = (
 export interface PostcssThemeOptions {
   /** Configuration given to the postcss plugin */
   config?: PostcssThemeConfig;
+  /** Class to apply to light theme overrides */
+  lightClass?: string;
+  /** Class to apply to dark theme overrides */
+  darkClass?: string;
   /** A function to resolve the theme file */
   resolveTheme?: ThemeResolver;
   /** LEGACY - Put empty selectors in final output */


### PR DESCRIPTION
# What Changed

see title

# Why

A user might want to customize these.

Todo:

- [x] Add tests
- [x] Add docs

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `2.7.1-canary.54.695`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
